### PR TITLE
Get real IP address if behind a proxy

### DIFF
--- a/mod_evasive24.c
+++ b/mod_evasive24.c
@@ -311,7 +311,7 @@ static int access_checker(request_rec *r)
                     }
 
                     if (cfg->system_command != NULL) {
-                        snprintf(filename, sizeof(filename), cfg->system_command, r->client_ip);
+                        snprintf(filename, sizeof(filename), cfg->system_command, client_ip);
                         system(filename);
                     }
 


### PR DESCRIPTION
When the apache is behind a proxy like a load-balancer then the value of `r->useragent_ip` contains the IP of that proxy server not the client. So, if there is a value in header `X-Forwarded-For` use that instead - which is provided by the proxy.

You usually use this with a config in your virtualhost:

```
  RemoteIPHeader X-Forwarded-For
  RemoteIPTrustedProxy x.x.x.x/16
```