### PR TITLE
Implement DOSLocking option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+Version 2.3.0
+-----------
+
+[20200312] gacha: Add DOSLocking config option
+[20200310] gacha: Pass request path to system command
+
 Version 2.2.0
 -----------
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,12 @@ system calls to ip filter or other tools.  A locking mechanism using /tmp
 prevents continuous system calls.  Use first %s to denote the IP address and
 second %s to get the last requested URI of the blacklisted IP.
 
+## DOSLocking
+
+By default it is set to `true` and notifications are sent only once per blocked
+IP. If you want to receive a notification each time the IP is blocked then set
+this to `false`.
+
 ## DOSLogDir
 
 Choose an alternative temp directory

--- a/dist/libapache2-mod-evasive/DEBIAN/control
+++ b/dist/libapache2-mod-evasive/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: libapache2-mod-evasive
-Version: 2.1.1
+Version: 2.3.0
 Maintainer: Joris Vandermeersch
 Architecture: all
 Description: evasive module to minimize HTTP DoS or brute force attacks


### PR DESCRIPTION
When using `DOSSystemCommand` to receive notifications you get one notification per IP, because the lock file is created after the first time the IP is blocked. But I would like to get a notification each time the IP address is blocked - that is when the `DOSBlockingPeriod` is over and the same IP is blocked again then I want to receive a new notification. 

The benefit of this is that you can monitor more precisely when someone is blocked and see if one IP is blocked multiple times.

The default behavior will stay the same as the default value for `DOSLocking` is `true`.  And this probably shouldn't be used together with `DOSEmailNotify`, to not receive too many emails.