### PR TITLE
Update mod_evasive24.c to prevent segfault

### DIFF
--- a/mod_evasive24.c
+++ b/mod_evasive24.c
@@ -420,12 +420,14 @@ int is_uri_whitelisted(const char *path, evasive_config *cfg) {
 
 static apr_status_t destroy_config(void *dconfig) {
     evasive_config *cfg = (evasive_config *) dconfig;
-    ntt_destroy(cfg->hit_list);
-    free(cfg->email_notify);
-    free(cfg->log_dir);
-    free(cfg->system_command);
-    free(cfg);
-    return APR_SUCCESS;
+    if (cfg != NULL) {
+      ntt_destroy(cfg->hit_list);
+      free(cfg->email_notify);
+      free(cfg->log_dir);
+      free(cfg->system_command);
+      free(cfg);
+   }
+   return APR_SUCCESS;
 }
 
 


### PR DESCRIPTION
destroy_config can be called with a NULL pointer.  Check on NULL pointer is required to prevent segfault in apache 2.4