### PR TITLE
Log format update

### DIFF
--- a/mod_evasive24.c
+++ b/mod_evasive24.c
@@ -580,8 +580,8 @@ static int access_checker(request_rec *r)
     if (log_reason && ret == cfg->http_reply
             && (ap_satisfies(r) != SATISFY_ANY || !ap_some_auth_required(r))) {
         ap_log_rerror(APLOG_MARK, APLOG_NOTICE, 0, r,
-                "client denied by server configuration: %s: %s",
-                log_reason, r->filename);
+                "[host %s] [resource \"%s\"] [reason %s] client denied by server configuration",
+                r->hostname, r->filename, log_reason);
     }
 
     return ret;


### PR DESCRIPTION
Include the requested hostname in the log message and use the common apache log format by putting key-value-pairs into square brackets.