### PR TITLE
Adjust default hashtable size

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ following block to your httpd.conf:
 ```
 <IfModule mod_evasive.c>
 	DOSEnabled          true
-	DOSHashTableSize    3097
+	DOSHashTableSize    3079
 	DOSPageCount        2
 	DOSSiteCount        50
 	DOSPageInterval     1

--- a/mod_evasive.conf
+++ b/mod_evasive.conf
@@ -1,7 +1,7 @@
 # vim:ts=4
 <IfModule mod_evasive.c>
 	DOSEnabled			true
-	DOSHashTableSize	3097
+	DOSHashTableSize	3079
 	DOSPageCount		2
 	DOSSiteCount		50
 	DOSPageInterval		1

--- a/mod_evasive20.c
+++ b/mod_evasive20.c
@@ -46,7 +46,7 @@ module AP_MODULE_DECLARE_DATA evasive_module;
 #define MAILER "/bin/mail %s"
 #define  LOG( A, ... ) { openlog("mod_evasive", LOG_PID, LOG_DAEMON); syslog( A, __VA_ARGS__ ); closelog(); }
 
-#define DEFAULT_HASH_TBL_SIZE   3097ul  // Default hash table size
+#define DEFAULT_HASH_TBL_SIZE   3079ul  // Default hash table size
 #define DEFAULT_PAGE_COUNT      2       // Default maximum page hit count per interval
 #define DEFAULT_SITE_COUNT      50      // Default maximum site hit count per interval
 #define DEFAULT_PAGE_INTERVAL   1       // Default 1 Second page interval

--- a/mod_evasive24.c
+++ b/mod_evasive24.c
@@ -47,7 +47,7 @@ AP_DECLARE_MODULE(evasive);
 
 #define MAILER  "/bin/mail %s"
 
-#define DEFAULT_HASH_TBL_SIZE   3097UL  // Default hash table size
+#define DEFAULT_HASH_TBL_SIZE   3079UL  // Default hash table size
 #define DEFAULT_PAGE_COUNT      2       // Default maximum page hit count per interval
 #define DEFAULT_SITE_COUNT      50      // Default maximum site hit count per interval
 #define DEFAULT_PAGE_INTERVAL   1       // Default 1 Second page interval

--- a/mod_evasive24win.c
+++ b/mod_evasive24win.c
@@ -62,7 +62,7 @@ module AP_MODULE_DECLARE_DATA evasive_module;
 
 /* BEGIN DoS Evasive Maneuvers Definitions */
 
-#define DEFAULT_HASH_TBL_SIZE   3097ul  // Default hash table size
+#define DEFAULT_HASH_TBL_SIZE   3079ul  // Default hash table size
 #define DEFAULT_PAGE_COUNT      2       // Default maximum page hit count per interval
 #define DEFAULT_SITE_COUNT      50      // Default maximum site hit count per interval
 #define DEFAULT_PAGE_INTERVAL   1       // Default 1 Second page interval

--- a/mod_evasiveNSAPI.c
+++ b/mod_evasiveNSAPI.c
@@ -53,7 +53,7 @@
 #define MAILER "/bin/mail %s"
 #define  LOG( A, ... ) { openlog("mod_dosevasive", LOG_PID, LOG_DAEMON); syslog( A, __VA_ARGS__ ); closelog(); }
 
-#define DEFAULT_HASH_TBL_SIZE   3097ul  // Default hash table size
+#define DEFAULT_HASH_TBL_SIZE   3079ul  // Default hash table size
 #define DEFAULT_PAGE_COUNT      2       // Default maximum page hit count per interval
 #define DEFAULT_SITE_COUNT      50      // Default maximum site hit count per interval
 #define DEFAULT_PAGE_INTERVAL   1       // Default 1 Second page interval

--- a/test/00_regular_config/etc/mod_evasive.conf
+++ b/test/00_regular_config/etc/mod_evasive.conf
@@ -1,7 +1,7 @@
 # vim:ts=4
 <IfModule mod_evasive.c>
 	DOSEnabled			true
-	DOSHashTableSize	3097
+	DOSHashTableSize	3079
 	DOSPageCount		2
 	DOSSiteCount		50
 	DOSPageInterval		1


### PR DESCRIPTION
The current default hashtable size configuration value of 3097 is probably a typo of 3079, since 3079 is a prime and an item of the embedded prime list.

As a result the actual default hashtable size changes from 6151 to 3079.

Closes: #39