### PR TITLE
Move module hook order up

### DIFF
--- a/mod_evasive24.c
+++ b/mod_evasive24.c
@@ -1150,7 +1150,7 @@ static const command_rec access_cmds[] =
 };
 
 static void register_hooks(apr_pool_t *p) {
-    ap_hook_access_checker(access_checker, NULL, NULL, APR_HOOK_MIDDLE);
+    ap_hook_access_checker(access_checker, NULL, NULL, APR_HOOK_FIRST-5);
     apr_pool_cleanup_register(p, NULL, apr_pool_cleanup_null, destroy_config);
 };
 


### PR DESCRIPTION
Instead of running mod_evasive in the middle, run in the first batch to avoid unnecessary computations for banned clients.

See https://httpd.apache.org/docs/current/developer/hooks.html#hooking-order