### PR TITLE
Update mod_evasive24.c

### DIFF
--- a/mod_evasive24.c
+++ b/mod_evasive24.c
@@ -544,7 +544,7 @@ static int access_checker(request_rec *r)
             if (stat(filename, &s)) {
                 file = fopen(filename, "w");
                 if (file != NULL) {
-                    fprintf(file, "%ld\n", getpid());
+                    fprintf(file, "%ld\n", (long int)getpid());
                     fclose(file);
 
                     ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, r, "Blacklisting address %s: possible DoS attack.", r->useragent_ip);
@@ -561,7 +561,10 @@ static int access_checker(request_rec *r)
 
                     if (cfg->system_command != NULL) {
                         snprintf(filename, sizeof(filename), cfg->system_command, r->useragent_ip);
-                        system(filename);
+                         int systemRet = system(filename);
+                         if(systemRet == -1){
+                                ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, "Couldn't execute %s %s ",filename, strerror(errno));
+                        }
                     }
 
                 } else {

--- a/mod_evasive24.c
+++ b/mod_evasive24.c
@@ -563,7 +563,7 @@ static int access_checker(request_rec *r)
                         snprintf(filename, sizeof(filename), cfg->system_command, r->useragent_ip);
                          int systemRet = system(filename);
                          if(systemRet == -1){
-                                ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, "Couldn't execute %s %s ",filename, strerror(errno));
+                                ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, "Couldn't execute %s %s ", filename, strerror(errno));
                         }
                     }
 


### PR DESCRIPTION
Fix two warnings during compilation:
´´´
mod_evasive24.c: In function 'access_checker':
mod_evasive24.c:547:38: warning: format '%ld' expects argument of type 'long int', but argument 3 has type '__pid_t' {aka 'int'} [-Wformat=]
  547 |                     fprintf(file, "%ld\n", getpid());
      |                                    ~~^     ~~~~~~~~
      |                                      |     |
      |                                      |     __pid_t {aka int}
      |                                      long int
      |                                    %d
mod_evasive24.c:564:25: warning: ignoring return value of 'system' declared with attribute 'warn_unused_result' [-Wunused-result]
  564 |                         system(filename);
      |                         ^~~~~~~~~~~~~~~~
´´´