### PR TITLE
Quote value in log message

### DIFF
--- a/mod_evasive24.c
+++ b/mod_evasive24.c
@@ -596,7 +596,7 @@ static int access_checker(request_rec *r)
     if (log_reason && ret == cfg->http_reply
             && (ap_satisfies(r) != SATISFY_ANY || !ap_some_auth_required(r))) {
         ap_log_rerror(APLOG_MARK, APLOG_NOTICE, 0, r,
-                "[host %s] [resource \"%s\"] [reason %s] client denied by server configuration",
+                "[host %s] [resource \"%s\"] [reason \"%s\"] client denied by server configuration",
                 r->hostname, r->filename, log_reason);
     }
 


### PR DESCRIPTION
The reason can consist of multiple words, e.g. `URI blocklist`, so quote it to comply with the usual format and not break field extraction during log analysis.